### PR TITLE
Correction for banner settings

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,6 +12,7 @@ sections:
         - title: Announcements
           description: Information for Parents
           url: /Announcements
+      variant: image
   - infopic:
       title: Primary 6 Graduation 2023
       id: infopic

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ sections:
         - title: Announcements
           description: Information for Parents
           url: /Announcements
-      variant: center
+      variant: image
       size: md
       alignment: right
       backgroundColor: gray

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ sections:
         - title: Announcements
           description: Information for Parents
           url: /Announcements
-      variant: image
+      variant: center
       size: md
       alignment: right
       backgroundColor: gray

--- a/index.md
+++ b/index.md
@@ -12,7 +12,10 @@ sections:
         - title: Announcements
           description: Information for Parents
           url: /Announcements
-      variant: center
+      variant: image
+      size: md
+      alignment: right
+      backgroundColor: gray
   - infopic:
       title: Primary 6 Graduation 2023
       id: infopic

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ sections:
         - title: Announcements
           description: Information for Parents
           url: /Announcements
-      variant: image
+      variant: center
   - infopic:
       title: Primary 6 Graduation 2023
       id: infopic


### PR DESCRIPTION
Should be set as "image only" instead of "centered-aligned text" which dims the banner image.